### PR TITLE
Fix dark mode text visibility issues

### DIFF
--- a/V2er/View/Explore/ExplorePage.swift
+++ b/V2er/View/Explore/ExplorePage.swift
@@ -41,7 +41,7 @@ struct ExplorePage: BaseHomePageView {
                     AvatarView(url: item.avatar, size: 30)
 //                        .to { UserDetailPage(userId: item.member) }
                     Text(item.title)
-                        .foregroundColor(.bodyText)
+                        .foregroundColor(Color.primaryText)
                         .lineLimit(2)
                         .greedyWidth(.leading)
                 }

--- a/V2er/View/Message/MessagePage.swift
+++ b/V2er/View/Message/MessagePage.swift
@@ -49,7 +49,7 @@ struct MessagePage: BaseHomePageView {
 struct MessageItemView: View {
     let item: MessageInfo.Item
     let quoteFont = Style.font(UIFont.prfered(.subheadline))
-        .foregroundColor(Color.bodyText.uiColor)
+        .foregroundColor(Color.secondaryText.uiColor)
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
@@ -57,6 +57,7 @@ struct MessageItemView: View {
                 .to { UserDetailPage(userId: item.username)}
             VStack(alignment: .leading) {
                 Text(item.title)
+                    .foregroundColor(Color.primaryText)
                     .greedyWidth(.leading)
                     .background(Color.itemBg)
                     .to { FeedDetailPage(id: item.feedId) }


### PR DESCRIPTION
## Summary
- Fixed text visibility issues in dark mode for Explore and Message pages
- Ensures all text elements use appropriate adaptive colors for both light and dark themes

## Changes
1. **Explore Page**: Updated "今日热议" (Today's Hot Topics) list item titles to use `Color.primaryText` instead of `.bodyText` for better dark mode visibility
2. **Message Page**: 
   - Added explicit `Color.primaryText` foreground color to message titles
   - Changed reply content text from `Color.bodyText` to `Color.secondaryText` for improved contrast in dark mode

## Test Plan
- [ ] Test Explore page in both light and dark modes
- [ ] Verify text visibility for hot topic items in Explore page
- [ ] Test Message page in both light and dark modes  
- [ ] Verify message titles and reply content are clearly visible in dark mode
- [ ] Ensure no regressions in light mode appearance

🤖 Generated with [Claude Code](https://claude.ai/code)