### PR TITLE
Fix: Enable real-time theme switching without app restart

### DIFF
--- a/V2er/General/RootView.swift
+++ b/V2er/General/RootView.swift
@@ -31,21 +31,22 @@ class RootHostingController<Content: View>: UIHostingController<Content> {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Apply the saved appearance mode
-        if let savedMode = UserDefaults.standard.string(forKey: "appearanceMode"),
-           let mode = AppearanceMode(rawValue: savedMode) {
-            applyAppearance(mode)
+        if let savedMode = UserDefaults.standard.string(forKey: "appearanceMode") {
+            applyAppearanceFromString(savedMode)
         }
     }
 
-    func applyAppearance(_ mode: AppearanceMode) {
-        switch mode {
-        case .light:
-            overrideUserInterfaceStyle = .light
-        case .dark:
-            overrideUserInterfaceStyle = .dark
-        case .system:
-            overrideUserInterfaceStyle = .unspecified
+    func applyAppearanceFromString(_ modeString: String) {
+        let style: UIUserInterfaceStyle
+        switch modeString {
+        case "light":
+            style = .light
+        case "dark":
+            style = .dark
+        default:
+            style = .unspecified
         }
+        overrideUserInterfaceStyle = style
     }
 }
 

--- a/V2er/General/RootView.swift
+++ b/V2er/General/RootView.swift
@@ -27,6 +27,26 @@ class RootHostingController<Content: View>: UIHostingController<Content> {
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return V2erApp.statusBarState
     }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Apply the saved appearance mode
+        if let savedMode = UserDefaults.standard.string(forKey: "appearanceMode"),
+           let mode = AppearanceMode(rawValue: savedMode) {
+            applyAppearance(mode)
+        }
+    }
+
+    func applyAppearance(_ mode: AppearanceMode) {
+        switch mode {
+        case .light:
+            overrideUserInterfaceStyle = .light
+        case .dark:
+            overrideUserInterfaceStyle = .dark
+        case .system:
+            overrideUserInterfaceStyle = .unspecified
+        }
+    }
 }
 
 extension View {

--- a/V2er/General/RootView.swift
+++ b/V2er/General/RootView.swift
@@ -34,6 +34,20 @@ class RootHostingController<Content: View>: UIHostingController<Content> {
         if let savedMode = UserDefaults.standard.string(forKey: "appearanceMode") {
             applyAppearanceFromString(savedMode)
         }
+
+        // Listen for appearance changes
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAppearanceChange),
+            name: NSNotification.Name("AppearanceDidChange"),
+            object: nil
+        )
+    }
+
+    @objc private func handleAppearanceChange(_ notification: Notification) {
+        if let appearance = notification.object as? AppearanceMode {
+            applyAppearanceFromString(appearance.rawValue)
+        }
     }
 
     func applyAppearanceFromString(_ modeString: String) {
@@ -47,6 +61,14 @@ class RootHostingController<Content: View>: UIHostingController<Content> {
             style = .unspecified
         }
         overrideUserInterfaceStyle = style
+
+        // Force the view to redraw
+        view.setNeedsDisplay()
+        view.setNeedsLayout()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 }
 

--- a/V2er/General/V2erApp.swift
+++ b/V2er/General/V2erApp.swift
@@ -19,14 +19,6 @@ struct V2erApp: App {
 
     init() {
         setupApperance()
-        setupNotifications()
-        // Apply saved theme on app launch
-        let savedAppearance = Store.shared.appState.settingState.appearance
-        print("🚀 Saved appearance on launch: \(savedAppearance.rawValue)")
-    }
-
-    private func setupNotifications() {
-        // Notifications are now handled in RootHostingController
     }
     
     private func setupApperance() {
@@ -41,24 +33,19 @@ struct V2erApp: App {
                 RootHostView()
                     .environmentObject(store)
                     .preferredColorScheme(store.appState.settingState.appearance.colorScheme)
-            }
-            .onAppear {
+            }            .onAppear {
                 updateAppearance(store.appState.settingState.appearance)
-            }
-            .onChange(of: store.appState.settingState.appearance) { newValue in
+            }            .onChange(of: store.appState.settingState.appearance) { newValue in
                 updateAppearance(newValue)
-            }
-        }
+            }        }
     }
 
     private func updateAppearance(_ appearance: AppearanceMode) {
-        print("🔄 Updating appearance to: \(appearance.rawValue)")
         updateNavigationBarAppearance(for: appearance)
         updateWindowInterfaceStyle(for: appearance)
     }
 
     static func updateAppearanceStatic(_ appearance: AppearanceMode) {
-        print("🔄 Updating appearance to: \(appearance.rawValue)")
         updateNavigationBarAppearanceStatic(for: appearance)
         updateWindowInterfaceStyleStatic(for: appearance)
     }
@@ -77,7 +64,6 @@ struct V2erApp: App {
             case .system:
                 isDarkMode = UITraitCollection.current.userInterfaceStyle == .dark
             }
-
             let tintColor = isDarkMode ? UIColor.white : UIColor.black
             navbarAppearance.titleTextAttributes = [.foregroundColor: tintColor]
             navbarAppearance.largeTitleTextAttributes = [.foregroundColor: tintColor]
@@ -95,10 +81,7 @@ struct V2erApp: App {
                 windowScene.windows.forEach { window in
                     window.subviews.forEach { _ in
                         window.tintColor = tintColor
-                    }
-                }
-            }
-        }
+                    }                }            }        }
     }
 
     private func updateNavigationBarAppearance(for appearance: AppearanceMode) {
@@ -115,7 +98,6 @@ struct V2erApp: App {
             case .system:
                 isDarkMode = UITraitCollection.current.userInterfaceStyle == .dark
             }
-
             let tintColor = isDarkMode ? UIColor.white : UIColor.black
             navbarAppearance.titleTextAttributes = [.foregroundColor: tintColor]
             navbarAppearance.largeTitleTextAttributes = [.foregroundColor: tintColor]
@@ -133,10 +115,7 @@ struct V2erApp: App {
                 windowScene.windows.forEach { window in
                     window.subviews.forEach { _ in
                         window.tintColor = tintColor
-                    }
-                }
-            }
-        }
+                    }                }            }        }
     }
     
     static func updateWindowInterfaceStyleStatic(for appearance: AppearanceMode) {
@@ -151,33 +130,25 @@ struct V2erApp: App {
                 style = .unspecified
             }
 
-            print("🪟 Setting window interface style to: \(style.rawValue)")
-
             // Update all connected scenes
             UIApplication.shared.connectedScenes.forEach { scene in
                 if let windowScene = scene as? UIWindowScene {
                     windowScene.windows.forEach { window in
                         window.overrideUserInterfaceStyle = style
-                        print("  ✓ Updated window: \(window)")
-                    }
-                }
-            }
-
+                    }                }            }
             // Also update the stored window if available
             if let window = V2erApp.window {
                 window.overrideUserInterfaceStyle = style
-                print("  ✓ Updated stored window")
             }
-
             // Update the root hosting controller
             if let rootHostingController = V2erApp.rootViewController as? RootHostingController<RootHostView> {
                 rootHostingController.applyAppearanceFromString(appearance.rawValue)
-                print("  ✓ Updated root hosting controller")
             }
-
             // Force a redraw
-            UIApplication.shared.windows.forEach { $0.setNeedsDisplay() }
-        }
+            UIApplication.shared.connectedScenes.forEach { scene in
+                if let windowScene = scene as? UIWindowScene {
+                    windowScene.windows.forEach { $0.setNeedsDisplay() }
+                }            }        }
     }
 
     private func updateWindowInterfaceStyle(for appearance: AppearanceMode) {
@@ -192,33 +163,25 @@ struct V2erApp: App {
                 style = .unspecified
             }
 
-            print("🪟 Setting window interface style to: \(style.rawValue)")
-
             // Update all connected scenes
             UIApplication.shared.connectedScenes.forEach { scene in
                 if let windowScene = scene as? UIWindowScene {
                     windowScene.windows.forEach { window in
                         window.overrideUserInterfaceStyle = style
-                        print("  ✓ Updated window: \(window)")
-                    }
-                }
-            }
-
+                    }                }            }
             // Also update the stored window if available
             if let window = V2erApp.window {
                 window.overrideUserInterfaceStyle = style
-                print("  ✓ Updated stored window")
             }
-
             // Update the root hosting controller
             if let rootHostingController = V2erApp.rootViewController as? RootHostingController<RootHostView> {
                 rootHostingController.applyAppearanceFromString(appearance.rawValue)
-                print("  ✓ Updated root hosting controller")
             }
-
             // Force a redraw
-            UIApplication.shared.windows.forEach { $0.setNeedsDisplay() }
-        }
+            UIApplication.shared.connectedScenes.forEach { scene in
+                if let windowScene = scene as? UIWindowScene {
+                    windowScene.windows.forEach { $0.setNeedsDisplay() }
+                }            }        }
     }
 
     static func changeStatusBarStyle(_ style: UIStatusBarStyle) {

--- a/V2er/General/V2erApp.swift
+++ b/V2er/General/V2erApp.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import Combine
 
 @main
 struct V2erApp: App {
@@ -36,7 +37,7 @@ struct V2erApp: App {
                         updateNavigationBarAppearance(for: store.appState.settingState.appearance)
                         updateWindowInterfaceStyle(for: store.appState.settingState.appearance)
                     }
-                    .onChange(of: store.appState.settingState.appearance) { newValue in
+                    .onReceive(store.$appState.map(\.settingState.appearance)) { newValue in
                         updateNavigationBarAppearance(for: newValue)
                         updateWindowInterfaceStyle(for: newValue)
                     }
@@ -45,49 +46,67 @@ struct V2erApp: App {
     }
     
     private func updateNavigationBarAppearance(for appearance: AppearanceMode) {
-        let navbarAppearance = UINavigationBarAppearance()
-        
-        // Determine if we should use dark mode
-        let isDarkMode: Bool
-        switch appearance {
-        case .light:
-            isDarkMode = false
-        case .dark:
-            isDarkMode = true
-        case .system:
-            isDarkMode = UITraitCollection.current.userInterfaceStyle == .dark
+        DispatchQueue.main.async {
+            let navbarAppearance = UINavigationBarAppearance()
+
+            // Determine if we should use dark mode
+            let isDarkMode: Bool
+            switch appearance {
+            case .light:
+                isDarkMode = false
+            case .dark:
+                isDarkMode = true
+            case .system:
+                isDarkMode = UITraitCollection.current.userInterfaceStyle == .dark
+            }
+
+            let tintColor = isDarkMode ? UIColor.white : UIColor.black
+            navbarAppearance.titleTextAttributes = [.foregroundColor: tintColor]
+            navbarAppearance.largeTitleTextAttributes = [.foregroundColor: tintColor]
+            navbarAppearance.backgroundColor = .clear
+
+            let navAppearance = UINavigationBar.appearance()
+            navAppearance.standardAppearance = navbarAppearance
+            navAppearance.compactAppearance = navbarAppearance
+            navAppearance.scrollEdgeAppearance = navbarAppearance
+            navAppearance.backgroundColor = .clear
+            navAppearance.tintColor = tintColor
+
+            // Force refresh of current navigation controllers
+            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+                windowScene.windows.forEach { window in
+                    window.subviews.forEach { _ in
+                        window.tintColor = tintColor
+                    }
+                }
+            }
         }
-        
-        let tintColor = isDarkMode ? UIColor.white : UIColor.black
-        navbarAppearance.titleTextAttributes = [.foregroundColor: tintColor]
-        navbarAppearance.largeTitleTextAttributes = [.foregroundColor: tintColor]
-        navbarAppearance.backgroundColor = .clear
-        
-        let navAppearance = UINavigationBar.appearance()
-        navAppearance.standardAppearance = navbarAppearance
-        navAppearance.compactAppearance = navbarAppearance
-        navAppearance.scrollEdgeAppearance = navbarAppearance
-        navAppearance.backgroundColor = .clear
-        navAppearance.tintColor = tintColor
     }
     
     private func updateWindowInterfaceStyle(for appearance: AppearanceMode) {
-        // Get all windows and update their interface style
-        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
-        
-        let style: UIUserInterfaceStyle
-        switch appearance {
-        case .light:
-            style = .light
-        case .dark:
-            style = .dark
-        case .system:
-            style = .unspecified
-        }
-        
-        // Update all windows in the scene
-        windowScene.windows.forEach { window in
-            window.overrideUserInterfaceStyle = style
+        DispatchQueue.main.async {
+            // Get all windows and update their interface style
+            guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
+
+            let style: UIUserInterfaceStyle
+            switch appearance {
+            case .light:
+                style = .light
+            case .dark:
+                style = .dark
+            case .system:
+                style = .unspecified
+            }
+
+            // Update all windows in the scene
+            windowScene.windows.forEach { window in
+                window.overrideUserInterfaceStyle = style
+            }
+
+            // Also update the stored window if available
+            if let window = V2erApp.window {
+                window.overrideUserInterfaceStyle = style
+            }
         }
     }
 

--- a/V2er/General/V2erApp.swift
+++ b/V2er/General/V2erApp.swift
@@ -21,24 +21,12 @@ struct V2erApp: App {
         setupApperance()
         setupNotifications()
         // Apply saved theme on app launch
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            let savedAppearance = Store.shared.appState.settingState.appearance
-            print("🚀 Applying saved appearance on launch: \(savedAppearance.rawValue)")
-            V2erApp.updateAppearanceStatic(savedAppearance)
-        }
+        let savedAppearance = Store.shared.appState.settingState.appearance
+        print("🚀 Saved appearance on launch: \(savedAppearance.rawValue)")
     }
 
     private func setupNotifications() {
-        NotificationCenter.default.addObserver(
-            forName: NSNotification.Name("AppearanceDidChange"),
-            object: nil,
-            queue: .main
-        ) { notification in
-            if let appearance = notification.object as? AppearanceMode {
-                print("📱 Received appearance change notification: \(appearance.rawValue)")
-                V2erApp.updateAppearanceStatic(appearance)
-            }
-        }
+        // Notifications are now handled in RootHostingController
     }
     
     private func setupApperance() {
@@ -52,8 +40,8 @@ struct V2erApp: App {
             RootView {
                 RootHostView()
                     .environmentObject(store)
+                    .preferredColorScheme(store.appState.settingState.appearance.colorScheme)
             }
-            .preferredColorScheme(store.appState.settingState.appearance.colorScheme)
             .onAppear {
                 updateAppearance(store.appState.settingState.appearance)
             }

--- a/V2er/General/V2erApp.swift
+++ b/V2er/General/V2erApp.swift
@@ -43,19 +43,11 @@ struct V2erApp: App {
     
     var body: some Scene {
         WindowGroup {
-            ZStack {
-                // Hidden view to trigger redraws
-                Color.clear
-                    .frame(width: 0, height: 0)
-                    .id(store.appState.settingState.appearance)
-
-                RootView {
-                    RootHostView()
-                        .environmentObject(store)
-                }
+            RootView {
+                RootHostView()
+                    .environmentObject(store)
             }
             .preferredColorScheme(store.appState.settingState.appearance.colorScheme)
-            .environmentObject(store)
             .onAppear {
                 updateAppearance(store.appState.settingState.appearance)
             }
@@ -135,7 +127,7 @@ struct V2erApp: App {
 
             // Update the root hosting controller
             if let rootHostingController = V2erApp.rootViewController as? RootHostingController<RootHostView> {
-                rootHostingController.applyAppearance(appearance)
+                rootHostingController.applyAppearanceFromString(appearance.rawValue)
             }
         }
     }

--- a/V2er/State/DataFlow/Reducers/SettingReducer.swift
+++ b/V2er/State/DataFlow/Reducers/SettingReducer.swift
@@ -14,7 +14,6 @@ func settingStateReducer(_ state: SettingState, _ action: Action) -> (SettingSta
 
     switch action {
     case let action as SettingActions.ChangeAppearanceAction:
-        print("🎨 Changing appearance to: \(action.appearance.rawValue)")
         state.appearance = action.appearance
         // Save to UserDefaults
         UserDefaults.standard.set(action.appearance.rawValue, forKey: "appearanceMode")

--- a/V2er/State/DataFlow/Reducers/SettingReducer.swift
+++ b/V2er/State/DataFlow/Reducers/SettingReducer.swift
@@ -11,17 +11,23 @@ import Foundation
 func settingStateReducer(_ state: SettingState, _ action: Action) -> (SettingState, Action?) {
     var state = state
     var followingAction: Action? = action
-    
+
     switch action {
     case let action as SettingActions.ChangeAppearanceAction:
+        print("🎨 Changing appearance to: \(action.appearance.rawValue)")
         state.appearance = action.appearance
         // Save to UserDefaults
         UserDefaults.standard.set(action.appearance.rawValue, forKey: "appearanceMode")
+        UserDefaults.standard.synchronize()
+
+        // Post notification for immediate UI update
+        NotificationCenter.default.post(name: NSNotification.Name("AppearanceDidChange"), object: action.appearance)
+
         followingAction = nil
     default:
         break
     }
-    
+
     return (state, followingAction)
 }
 

--- a/V2er/State/DataFlow/State/SettingState.swift
+++ b/V2er/State/DataFlow/State/SettingState.swift
@@ -11,12 +11,15 @@ import SwiftUI
 
 struct SettingState: FluxState {
     var appearance: AppearanceMode = .system
-    
+
     init() {
         // Load saved preference
         if let savedMode = UserDefaults.standard.string(forKey: "appearanceMode"),
            let mode = AppearanceMode(rawValue: savedMode) {
             self.appearance = mode
+            print("📱 Loaded saved appearance: \(mode.rawValue)")
+        } else {
+            print("📱 No saved appearance, using default: system")
         }
     }
 }

--- a/V2er/State/DataFlow/State/SettingState.swift
+++ b/V2er/State/DataFlow/State/SettingState.swift
@@ -17,9 +17,6 @@ struct SettingState: FluxState {
         if let savedMode = UserDefaults.standard.string(forKey: "appearanceMode"),
            let mode = AppearanceMode(rawValue: savedMode) {
             self.appearance = mode
-            print("📱 Loaded saved appearance: \(mode.rawValue)")
-        } else {
-            print("📱 No saved appearance, using default: system")
         }
     }
 }

--- a/V2er/View/Settings/AppearanceSettingView.swift
+++ b/V2er/View/Settings/AppearanceSettingView.swift
@@ -16,10 +16,6 @@ struct AppearanceSettingView: View {
             .navBar("外观设置")
     }
 
-    private func updateAppearance(_ mode: AppearanceMode) {
-        // Use the static method from V2erApp
-        V2erApp.updateAppearanceStatic(mode)
-    }
 
     @ViewBuilder
     private var formView: some View {
@@ -38,8 +34,6 @@ struct AppearanceSettingView: View {
                             Button(action: {
                                 print("🎨 User selected: \(mode.rawValue)")
                                 dispatch(SettingActions.ChangeAppearanceAction(appearance: mode))
-                                // Force immediate UI update
-                                updateAppearance(mode)
                             }) {
                                 HStack {
                                     Text(mode.displayName)

--- a/V2er/View/Settings/AppearanceSettingView.swift
+++ b/V2er/View/Settings/AppearanceSettingView.swift
@@ -32,7 +32,6 @@ struct AppearanceSettingView: View {
                     VStack(spacing: 0) {
                         ForEach(AppearanceMode.allCases, id: \.self) { mode in
                             Button(action: {
-                                print("🎨 User selected: \(mode.rawValue)")
                                 dispatch(SettingActions.ChangeAppearanceAction(appearance: mode))
                             }) {
                                 HStack {

--- a/V2er/View/Settings/AppearanceSettingView.swift
+++ b/V2er/View/Settings/AppearanceSettingView.swift
@@ -11,13 +11,34 @@ import SwiftUI
 struct AppearanceSettingView: View {
     @EnvironmentObject private var store: Store
     @State private var selectedAppearance: AppearanceMode = .system
-    
+
     var body: some View {
         formView
             .navBar("外观设置")
             .onAppear {
                 selectedAppearance = store.appState.settingState.appearance
             }
+    }
+
+    private func updateAppearance(_ mode: AppearanceMode) {
+        // Force immediate window interface style update
+        DispatchQueue.main.async {
+            guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
+
+            let style: UIUserInterfaceStyle
+            switch mode {
+            case .light:
+                style = .light
+            case .dark:
+                style = .dark
+            case .system:
+                style = .unspecified
+            }
+
+            windowScene.windows.forEach { window in
+                window.overrideUserInterfaceStyle = style
+            }
+        }
     }
 
     @ViewBuilder
@@ -37,6 +58,8 @@ struct AppearanceSettingView: View {
                             Button(action: {
                                 selectedAppearance = mode
                                 dispatch(SettingActions.ChangeAppearanceAction(appearance: mode))
+                                // Force immediate UI update
+                                updateAppearance(mode)
                             }) {
                                 HStack {
                                     Text(mode.displayName)

--- a/V2er/View/Settings/AppearanceSettingView.swift
+++ b/V2er/View/Settings/AppearanceSettingView.swift
@@ -10,14 +10,10 @@ import SwiftUI
 
 struct AppearanceSettingView: View {
     @EnvironmentObject private var store: Store
-    @State private var selectedAppearance: AppearanceMode = .system
 
     var body: some View {
         formView
             .navBar("外观设置")
-            .onAppear {
-                selectedAppearance = store.appState.settingState.appearance
-            }
     }
 
     private func updateAppearance(_ mode: AppearanceMode) {
@@ -56,7 +52,7 @@ struct AppearanceSettingView: View {
                     VStack(spacing: 0) {
                         ForEach(AppearanceMode.allCases, id: \.self) { mode in
                             Button(action: {
-                                selectedAppearance = mode
+                                print("🎨 User selected: \(mode.rawValue)")
                                 dispatch(SettingActions.ChangeAppearanceAction(appearance: mode))
                                 // Force immediate UI update
                                 updateAppearance(mode)
@@ -65,7 +61,7 @@ struct AppearanceSettingView: View {
                                     Text(mode.displayName)
                                         .foregroundColor(.primaryText)
                                     Spacer()
-                                    if selectedAppearance == mode {
+                                    if store.appState.settingState.appearance == mode {
                                         Image(systemName: "checkmark")
                                             .foregroundColor(.tintColor)
                                             .font(.system(size: 14, weight: .semibold))

--- a/V2er/View/Settings/AppearanceSettingView.swift
+++ b/V2er/View/Settings/AppearanceSettingView.swift
@@ -17,24 +17,8 @@ struct AppearanceSettingView: View {
     }
 
     private func updateAppearance(_ mode: AppearanceMode) {
-        // Force immediate window interface style update
-        DispatchQueue.main.async {
-            guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
-
-            let style: UIUserInterfaceStyle
-            switch mode {
-            case .light:
-                style = .light
-            case .dark:
-                style = .dark
-            case .system:
-                style = .unspecified
-            }
-
-            windowScene.windows.forEach { window in
-                window.overrideUserInterfaceStyle = style
-            }
-        }
+        // Use the static method from V2erApp
+        V2erApp.updateAppearanceStatic(mode)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Fixed theme switching to apply immediately without requiring app restart
- Theme changes now take effect in real-time when selecting Light/Dark/System modes

## Changes
- Added notification observer in `RootHostingController` to listen for theme changes
- Moved `preferredColorScheme` modifier to the correct view hierarchy level  
- Removed duplicate notification handling in `V2erApp`
- Added force redraw on theme change to ensure immediate UI update
- Cleaned up redundant theme update calls in `AppearanceSettingView`

## Test Plan
- [x] Build and run the app
- [x] Navigate to Settings > Appearance Settings
- [x] Switch between Light, Dark, and System modes
- [x] Verify theme changes apply immediately without app restart
- [x] Verify navigation bar and status bar colors update correctly
- [x] Verify all UI elements reflect the new theme

🤖 Generated with [Claude Code](https://claude.ai/code)