### PR TITLE
Fix: Update CI pipelines to use Xcode 16.0

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -48,7 +48,7 @@ jobs:
         submodules: recursive
     
     - name: Select Xcode version
-      run: sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/Xcode_16.0.app/Contents/Developer
     
     - name: Install xcpretty
       run: gem install xcpretty

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -59,7 +59,7 @@ jobs:
           -project V2er.xcodeproj \
           -scheme V2er \
           -sdk iphonesimulator \
-          -destination 'platform=iOS Simulator,name=iPhone 15' \
+          -destination 'platform=iOS Simulator,name=iPhone 16' \
           -enableCodeCoverage YES \
           -derivedDataPath build/DerivedData \
           CODE_SIGN_IDENTITY="" \

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -18,7 +18,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
     
     - name: Select Xcode version
-      run: sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/Xcode_16.0.app/Contents/Developer
     
     - name: Update Swift packages
       run: |

--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -22,7 +22,7 @@ jobs:
         submodules: recursive
     
     - name: Select Xcode version
-      run: sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/Xcode_16.0.app/Contents/Developer
     
     - name: Show Xcode version
       run: xcodebuild -version

--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -50,7 +50,7 @@ jobs:
           -project V2er.xcodeproj \
           -scheme V2er \
           -sdk iphonesimulator \
-          -destination 'platform=iOS Simulator,name=iPhone 15' \
+          -destination 'platform=iOS Simulator,name=iPhone 16' \
           ONLY_ACTIVE_ARCH=YES \
           CODE_SIGN_IDENTITY="" \
           CODE_SIGNING_REQUIRED=NO | xcpretty --color
@@ -61,7 +61,7 @@ jobs:
           -project V2er.xcodeproj \
           -scheme V2er \
           -sdk iphonesimulator \
-          -destination 'platform=iOS Simulator,name=iPhone 15' \
+          -destination 'platform=iOS Simulator,name=iPhone 16' \
           ONLY_ACTIVE_ARCH=YES \
           CODE_SIGN_IDENTITY="" \
           CODE_SIGNING_REQUIRED=NO | xcpretty --color --test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         fetch-depth: 0
     
     - name: Select Xcode version
-      run: sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/Xcode_16.0.app/Contents/Developer
     
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Summary
- Updated all GitHub Actions workflows to use Xcode 16.0 (latest stable version)
- Resolves CI build failures caused by invalid Xcode 15.4 path

## Changes
- Updated Xcode version from 15.4 to 16.0 in all workflow files:
  - `.github/workflows/ios-build-test.yml`
  - `.github/workflows/code-quality.yml`  
  - `.github/workflows/dependency-update.yml`
  - `.github/workflows/release.yml`

## Why This Change?
The CI builds were failing with:
```
xcode-select: error: invalid developer directory '/Applications/Xcode_15.4.app/Contents/Developer'
```

GitHub Actions runners now have Xcode 16.0 as the latest stable version available.

## Test Plan
- [x] Updated all workflow files consistently
- [ ] CI checks should pass with the new Xcode version
- [ ] Build and test workflows should complete successfully

🤖 Generated with [Claude Code](https://claude.ai/code)