### PR TITLE
fix: prevent WebView white flash in dark mode

### DIFF
--- a/V2er/View/FeedDetail/HtmlView.swift
+++ b/V2er/View/FeedDetail/HtmlView.swift
@@ -66,6 +66,13 @@ fileprivate struct Webview: UIViewRepresentable, WebViewHandlerDelegate {
         webView.allowsBackForwardNavigationGestures = false
         webView.scrollView.isScrollEnabled = false
         webView.configuration.defaultWebpagePreferences.allowsContentJavaScript = true
+
+        // Set WebView background based on current UI mode to prevent white flash
+        let isDark = determineIsDarkMode()
+        webView.isOpaque = false
+        webView.backgroundColor = isDark ? UIColor(red: 0.067, green: 0.071, blue: 0.078, alpha: 1.0) : UIColor.white
+        webView.scrollView.backgroundColor = isDark ? UIColor(red: 0.067, green: 0.071, blue: 0.078, alpha: 1.0) : UIColor.white
+
         return webView
     }
 
@@ -74,22 +81,31 @@ fileprivate struct Webview: UIViewRepresentable, WebViewHandlerDelegate {
 //        if rendered { return }
         var content = Bundle.readString(name: "v2er", type: "html")
         // Determine dark mode based on app appearance setting
-        let isDark: Bool
-        let appearance = store.appState.settingState.appearance
-        switch appearance {
-        case .dark:
-            isDark = true
-        case .light:
-            isDark = false
-        case .system:
-            isDark = colorScheme == .dark
-        }
+        let isDark = determineIsDarkMode()
+
+        // Update WebView background color to match current UI mode
+        webView.isOpaque = false
+        webView.backgroundColor = isDark ? UIColor(red: 0.067, green: 0.071, blue: 0.078, alpha: 1.0) : UIColor.white
+        webView.scrollView.backgroundColor = isDark ? UIColor(red: 0.067, green: 0.071, blue: 0.078, alpha: 1.0) : UIColor.white
+
         let fontSize = 16
         let params = "\(isDark), \(fontSize)"
         content = content?.replace(segs: "{injecttedContent}", with: html ?? .empty)
                           .replace(segs: "{INJECT_PARAMS}", with: params)
         let baseUrl = Bundle.main.bundleURL
         webView.loadHTMLString(content ?? .empty, baseURL: baseUrl)
+    }
+
+    private func determineIsDarkMode() -> Bool {
+        let appearance = store.appState.settingState.appearance
+        switch appearance {
+        case .dark:
+            return true
+        case .light:
+            return false
+        case .system:
+            return colorScheme == .dark
+        }
     }
 
     func receivedJsonValueFromWebView(value: [String : Any?]) {


### PR DESCRIPTION
## Summary
- Fixed WebView showing white background before content loads in dark mode
- Set initial WebView background color based on current UI mode
- Background now matches app theme immediately on load

## Changes
- Added determineIsDarkMode() helper function for consistent dark mode detection
- Set WebView and scrollView background colors in both makeUIView and updateUIView
- Used dark gray color (#111214) for dark mode to match existing CSS styling

## Test Plan
- [x] Build succeeds
- [ ] Test in light mode - WebView should show white background
- [ ] Test in dark mode - WebView should show dark background without flash
- [ ] Test switching between light/dark modes - background should update

🤖 Generated with [Claude Code](https://claude.ai/code)