### PR TITLE
Fix: Post detail title visibility issue

### DIFF
--- a/V2er/View/FeedDetail/AuthorInfoView.swift
+++ b/V2er/View/FeedDetail/AuthorInfoView.swift
@@ -69,7 +69,7 @@ struct AuthorInfoView: View {
             }
             Text(title)
                 .font(.headline)
-                .foregroundColor(.bodyText)
+                .foregroundColor(.primaryText)
                 .greedyWidth(.leading)
                 .padding(.top, 10)
                 .debug()


### PR DESCRIPTION
## Summary
- Fixed post title not displaying properly in the post detail page
- Changed title text color from `.bodyText` to `.primaryText` for better visibility

## Problem
The post title in the feed detail page was using `.bodyText` color which has low opacity (0.75 alpha in light mode), making it appear empty or very hard to see against the background.

## Solution
Changed the foreground color from `.bodyText` to `.primaryText` which provides better contrast and is consistent with other text elements in the same view.

## Test plan
- [ ] Open any post in the detail view
- [ ] Verify the post title is clearly visible above the content
- [ ] Test in both light and dark modes if supported
- [ ] Ensure title text color matches other primary text elements

🤖 Generated with [Claude Code](https://claude.ai/code)