### PR TITLE
Fix: Improve UI text and icon visibility in dark mode

### DIFF
--- a/V2er/View/Widget/SectionTitleView.swift
+++ b/V2er/View/Widget/SectionTitleView.swift
@@ -25,7 +25,7 @@ struct SectionTitleView: View {
         Text(title)
             .font(style == .normal ? .headline : .subheadline)
             .fontWeight(.heavy)
-            .foregroundColor(.bodyText)
+            .foregroundColor(.primaryText)
             .padding(.vertical, 8)
             .padding(.horizontal, style == .normal ? 2 : 8)
             .background {

--- a/V2er/View/Widget/TabBar.swift
+++ b/V2er/View/Widget/TabBar.swift
@@ -38,6 +38,7 @@ struct TabBar: View {
                                 .frame(height: 3)
                                 .cornerRadius(0)
                             Image(tab.icon)
+                                .renderingMode(.template)
                                 .resizable()
                                 .scaledToFit()
                                 .frame(height: 18)
@@ -57,7 +58,7 @@ struct TabBar: View {
                                 .fontWeight(isSelected ? .semibold : .regular)
                                 .padding(.bottom, 8)
                         }
-                        .foregroundColor(Color.tintColor)
+                        .foregroundColor(isSelected ? Color.tintColor : Color.tintColor.opacity(0.6))
                         .background(self.bg(isSelected: isSelected))
                         .padding(.horizontal, 16)
                         .background(Color.almostClear)


### PR DESCRIPTION
## Summary
This PR fixes visibility issues with UI elements in dark mode by improving color contrast for better readability.

## Changes Made
1. **Section title visibility fix**
   - Changed section title color from `bodyText` to `primaryText` for better contrast
   - Affects all section headers in Explore page including "今日热议", "最热节点", "新增节点", and "节点导航"

2. **Tab bar icon improvements for dark mode**
   - Added `.renderingMode(.template)` to tab icons to enable proper tinting
   - Applied different opacity for selected (100%) vs unselected (60%) tab items  
   - Icons now properly use `TintColor` which automatically switches to white in dark mode
   - Improved visual hierarchy with clearer selected/unselected state distinction

## Testing
- [x] Built and tested on physical device
- [x] Verified section titles are visible in both light and dark modes
- [x] Confirmed tab bar icons show proper contrast in dark mode
- [x] Tested selected/unselected tab states

## Screenshots
The changes improve the visibility of UI elements that were previously hard to see in dark mode due to insufficient color contrast.

Fixes visibility issues reported in dark mode usage.