### PR TITLE
Fix: Search results text colors for dark mode

### DIFF
--- a/V2er/View/Explore/SearchPage.swift
+++ b/V2er/View/Explore/SearchPage.swift
@@ -111,16 +111,17 @@ fileprivate struct SearchResultItemView: View {
         VStack(alignment: .leading) {
             Text(data.title)
                 .fontWeight(.semibold)
+                .foregroundColor(.primaryText)
                 .greedyWidth(.leading)
                 .lineLimit(2)
             Text(data.content)
+                .foregroundColor(.secondaryText)
                 .lineLimit(5)
                 .padding(.vertical, 5)
             Text("\(data.creator) 于 \(data.created) 发表, \(data.replyNum) 回复")
                 .font(.footnote)
                 .foregroundColor(Color.tintColor.opacity(0.8))
         }
-        .foregroundColor(Color.bodyText)
         .greedyWidth()
         .padding(padding)
         .background(Color.itemBg)


### PR DESCRIPTION
## Summary
- Fixed text color adaptation issues in search results for dark mode
- Ensures proper text visibility in both light and dark themes

## Changes
- Changed title text to use `.primaryText` for better dark mode support
- Changed content text to use `.secondaryText` for visual hierarchy
- Removed redundant `.foregroundColor(Color.bodyText)` modifier that was preventing proper color adaptation

## Test plan
- [x] Tested search results display in light mode
- [x] Tested search results display in dark mode
- [x] Verified text is clearly visible in both themes

🤖 Generated with [Claude Code](https://claude.ai/code)