### PR TITLE
Fix: WebView background color consistency in dark mode

### DIFF
--- a/V2er/View/FeedDetail/HtmlView.swift
+++ b/V2er/View/FeedDetail/HtmlView.swift
@@ -70,8 +70,8 @@ fileprivate struct Webview: UIViewRepresentable, WebViewHandlerDelegate {
         // Set WebView background based on current UI mode to prevent white flash
         let isDark = determineIsDarkMode()
         webView.isOpaque = false
-        webView.backgroundColor = isDark ? UIColor(red: 0.067, green: 0.071, blue: 0.078, alpha: 1.0) : UIColor.white
-        webView.scrollView.backgroundColor = isDark ? UIColor(red: 0.067, green: 0.071, blue: 0.078, alpha: 1.0) : UIColor.white
+        webView.backgroundColor = isDark ? UIColor(red: 0x1C/255.0, green: 0x1C/255.0, blue: 0x1E/255.0, alpha: 1.0) : UIColor.white
+        webView.scrollView.backgroundColor = isDark ? UIColor(red: 0x1C/255.0, green: 0x1C/255.0, blue: 0x1E/255.0, alpha: 1.0) : UIColor.white
 
         return webView
     }
@@ -85,8 +85,8 @@ fileprivate struct Webview: UIViewRepresentable, WebViewHandlerDelegate {
 
         // Update WebView background color to match current UI mode
         webView.isOpaque = false
-        webView.backgroundColor = isDark ? UIColor(red: 0.067, green: 0.071, blue: 0.078, alpha: 1.0) : UIColor.white
-        webView.scrollView.backgroundColor = isDark ? UIColor(red: 0.067, green: 0.071, blue: 0.078, alpha: 1.0) : UIColor.white
+        webView.backgroundColor = isDark ? UIColor(red: 0x1C/255.0, green: 0x1C/255.0, blue: 0x1E/255.0, alpha: 1.0) : UIColor.white
+        webView.scrollView.backgroundColor = isDark ? UIColor(red: 0x1C/255.0, green: 0x1C/255.0, blue: 0x1E/255.0, alpha: 1.0) : UIColor.white
 
         let fontSize = 16
         let params = "\(isDark), \(fontSize)"

--- a/V2er/www/v2er.css
+++ b/V2er/www/v2er.css
@@ -29,7 +29,7 @@ img {
 }
 
 .dark .topic_content{
-    background:#111214;
+    background:#1C1C1E;
     color:#7F8082;
 }
 
@@ -43,7 +43,7 @@ div.subtle {
 }
 
 .dark div.subtle {
-    background:#08090b;
+    background:#141416;
 }
 
 blockquote {
@@ -56,7 +56,7 @@ blockquote {
 }
 
 .dark blockquote {
-    background:#08090b;
+    background:#141416;
     color:#7F8082;
 }
 
@@ -66,11 +66,11 @@ div.subtle blockquote {
 }
 
 .dark div.subtle blockquote {
-    background:#08090b;
+    background:#141416;
 }
 
 .dark div.subtle .topic_content {
-    background:#08090b;
+    background:#141416;
 }
 
 div.subtle span.fade {


### PR DESCRIPTION
## Summary
- Fixed WebView background color mismatch in dark mode for post detail content
- Ensures seamless visual integration between WebView and native UI

## Problem
The WebView content area in post details had a darker background (#111214) compared to the app's ItemBackground color (#1C1C1E), creating a visual inconsistency in dark mode.

## Solution
- Updated WebView UIColor background to match ItemBackground.colorset (#1C1C1E)
- Updated CSS dark mode backgrounds to use the same color
- Adjusted subtle/blockquote backgrounds to #141416 for proper contrast hierarchy

## Test plan
- [x] Verified WebView background matches app background in dark mode
- [x] Tested post content display with various content types (text, code, quotes)
- [x] Confirmed no visual issues in light mode
- [x] Checked that subtle content blocks have appropriate contrast

🤖 Generated with [Claude Code](https://claude.ai/code)