### PR TITLE
feat: improve 'No more data' text style

### DIFF
--- a/V2er/View/Widget/Updatable/LoadmoreIndicatorView.swift
+++ b/V2er/View/Widget/Updatable/LoadmoreIndicatorView.swift
@@ -21,7 +21,8 @@ struct LoadmoreIndicatorView: View {
         Group {
             if !hasMoreData {
                 Text("No more data")
-                    .font(.callout)
+                    .font(.caption)
+                    .foregroundColor(.secondaryText)
             } else if isLoading {
                 ActivityIndicator()
             } else {


### PR DESCRIPTION
## Summary
- Changed font size from `.callout` to `.caption` for smaller text
- Added `.foregroundColor(.secondaryText)` for lighter, more subtle appearance
- Makes the end-of-content indicator less prominent in the UI

## Changes
Modified the `LoadmoreIndicatorView` to display "No more data" text with:
- Smaller font size using `.caption`
- Lighter color using `.secondaryText` (consistent with app's secondary text styling)

This improves the visual hierarchy by making the end-of-content indicator less prominent while maintaining readability.

🤖 Generated with [Claude Code](https://claude.ai/code)