### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/V2er.xcodeproj/project.pbxproj
+++ b/V2er.xcodeproj/project.pbxproj
@@ -1131,7 +1131,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_ASSET_PATHS = "\"V2er/Preview Content\"";
 				DEVELOPMENT_TEAM = DZCZQ4694Z;
 				ENABLE_PREVIEWS = YES;
@@ -1143,7 +1143,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = v2er.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1158,7 +1158,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_ASSET_PATHS = "\"V2er/Preview Content\"";
 				DEVELOPMENT_TEAM = DZCZQ4694Z;
 				ENABLE_PREVIEWS = YES;
@@ -1170,7 +1170,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = v2er.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Summary
- Bump app version from 1.0.1 to 1.1.0
- Increment build number from 2 to 3

## Changes
- Updated MARKETING_VERSION to 1.1.0
- Updated CURRENT_PROJECT_VERSION to 3

This prepares the app for the next release.

🤖 Generated with [Claude Code](https://claude.ai/code)