### PR TITLE
chore: bump version to 1.1.1 (build 4)

### DIFF
--- a/V2er.xcodeproj/project.pbxproj
+++ b/V2er.xcodeproj/project.pbxproj
@@ -1131,7 +1131,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_ASSET_PATHS = "\"V2er/Preview Content\"";
 				DEVELOPMENT_TEAM = DZCZQ4694Z;
 				ENABLE_PREVIEWS = YES;
@@ -1143,7 +1143,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = v2er.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1158,7 +1158,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_ASSET_PATHS = "\"V2er/Preview Content\"";
 				DEVELOPMENT_TEAM = DZCZQ4694Z;
 				ENABLE_PREVIEWS = YES;
@@ -1170,7 +1170,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = v2er.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Summary
- Updated app version from 1.1.0 to 1.1.1
- Incremented build number from 3 to 4
- This will trigger the release pipeline when merged

## Purpose
Testing the complete iOS release pipeline with Fastlane Match integration.

🤖 Generated with [Claude Code](https://claude.ai/code)