### PR TITLE
fix: update release pipeline for xcconfig-based version management

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'V2er/Info.plist'
-      - 'V2er.xcodeproj/project.pbxproj'
+      - 'V2er/Config/Version.xcconfig'
   workflow_dispatch:
     inputs:
       force_release:
@@ -38,9 +37,9 @@ jobs:
     - name: Check version and create tag if needed
       id: check
       run: |
-        # Get current version from project.pbxproj (works on Linux)
-        CURRENT_VERSION=$(grep -m1 'MARKETING_VERSION = ' V2er.xcodeproj/project.pbxproj | sed 's/.*MARKETING_VERSION = \(.*\);/\1/' | xargs)
-        CURRENT_BUILD=$(grep -m1 'CURRENT_PROJECT_VERSION = ' V2er.xcodeproj/project.pbxproj | sed 's/.*CURRENT_PROJECT_VERSION = \(.*\);/\1/' | xargs)
+        # Get current version from Version.xcconfig (works on Linux)
+        CURRENT_VERSION=$(grep '^MARKETING_VERSION = ' V2er/Config/Version.xcconfig | sed 's/.*MARKETING_VERSION = //' | xargs)
+        CURRENT_BUILD=$(grep '^CURRENT_PROJECT_VERSION = ' V2er/Config/Version.xcconfig | sed 's/.*CURRENT_PROJECT_VERSION = //' | xargs)
 
         echo "Current version: $CURRENT_VERSION (build $CURRENT_BUILD)"
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -22,7 +22,17 @@ This project uses two version identifiers:
 
 ### How to Update Versions
 
-To update versions, simply edit the file `V2er/Config/Version.xcconfig`:
+#### Option 1: Use the Update Script (Recommended)
+```bash
+# Interactive mode
+./scripts/update-version.sh
+
+# Or with arguments
+./scripts/update-version.sh 1.1.3 31
+```
+
+#### Option 2: Manual Edit
+Edit the file `V2er/Config/Version.xcconfig`:
 
 ```bash
 # Open the file
@@ -30,7 +40,7 @@ V2er/Config/Version.xcconfig
 
 # Update these two lines:
 MARKETING_VERSION = 1.1.2         # VERSION_NAME (user-facing version)
-CURRENT_PROJECT_VERSION = 29       # VERSION_CODE (build number)
+CURRENT_PROJECT_VERSION = 30       # VERSION_CODE (build number)
 ```
 
 **That's it!** No need to edit project.pbxproj or any other files. The xcconfig file is automatically loaded by Xcode and applies to all build configurations.

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Script to update app version
+# Usage: ./scripts/update-version.sh [version] [build]
+# Example: ./scripts/update-version.sh 1.1.3 31
+
+CONFIG_FILE="V2er/Config/Version.xcconfig"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to display current version
+show_current_version() {
+    CURRENT_VERSION=$(grep '^MARKETING_VERSION = ' "$CONFIG_FILE" | sed 's/.*MARKETING_VERSION = //' | xargs)
+    CURRENT_BUILD=$(grep '^CURRENT_PROJECT_VERSION = ' "$CONFIG_FILE" | sed 's/.*CURRENT_PROJECT_VERSION = //' | xargs)
+    echo -e "${YELLOW}Current version: ${NC}$CURRENT_VERSION (build $CURRENT_BUILD)"
+}
+
+# Function to update version
+update_version() {
+    local new_version=$1
+    local new_build=$2
+
+    # Update MARKETING_VERSION
+    sed -i '' "s/^MARKETING_VERSION = .*/MARKETING_VERSION = $new_version/" "$CONFIG_FILE"
+
+    # Update CURRENT_PROJECT_VERSION
+    sed -i '' "s/^CURRENT_PROJECT_VERSION = .*/CURRENT_PROJECT_VERSION = $new_build/" "$CONFIG_FILE"
+
+    echo -e "${GREEN}✅ Version updated successfully!${NC}"
+}
+
+# Main script
+echo -e "${GREEN}=== V2er Version Update Tool ===${NC}\n"
+
+# Show current version
+show_current_version
+
+# If no arguments provided, run in interactive mode
+if [ $# -eq 0 ]; then
+    echo ""
+    read -p "Enter new version (e.g., 1.1.3): " NEW_VERSION
+    read -p "Enter new build number (e.g., 31): " NEW_BUILD
+
+    if [ -z "$NEW_VERSION" ] || [ -z "$NEW_BUILD" ]; then
+        echo -e "${RED}❌ Error: Version and build number are required${NC}"
+        exit 1
+    fi
+else
+    # Use provided arguments
+    NEW_VERSION=$1
+    NEW_BUILD=$2
+
+    if [ -z "$NEW_VERSION" ] || [ -z "$NEW_BUILD" ]; then
+        echo -e "${RED}❌ Error: Usage: $0 <version> <build>${NC}"
+        echo "Example: $0 1.1.3 31"
+        exit 1
+    fi
+fi
+
+# Confirm update
+echo ""
+echo -e "${YELLOW}Will update to:${NC} $NEW_VERSION (build $NEW_BUILD)"
+read -p "Proceed? (y/n): " -n 1 -r
+echo ""
+
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    update_version "$NEW_VERSION" "$NEW_BUILD"
+    echo ""
+    show_current_version
+    echo ""
+    echo -e "${YELLOW}Next steps:${NC}"
+    echo "1. Commit the changes: git add -A && git commit -m \"chore: bump version to $NEW_VERSION (build $NEW_BUILD)\""
+    echo "2. Push to trigger release: git push"
+else
+    echo -e "${RED}❌ Update cancelled${NC}"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
Updated release pipeline to work with the new centralized version management in Version.xcconfig

## Changes
1. **Updated workflow trigger** - Now watches `V2er/Config/Version.xcconfig` for changes
2. **Fixed version detection** - Reads versions from xcconfig instead of project.pbxproj
3. **Added update script** - `scripts/update-version.sh` for easy version updates
4. **Updated documentation** - Added script usage instructions

## How it Works
1. When `Version.xcconfig` is updated and pushed to main → triggers version check
2. Version check creates a new tag if it doesn't exist → triggers build
3. Build job uploads to TestFlight

## Testing
- Tested update script successfully updates versions
- Workflow correctly reads versions from xcconfig file
- Manual tag creation still triggers the build pipeline

🤖 Generated with [Claude Code](https://claude.ai/code)