### PR TITLE
Update TestFlight release channel from internal to public beta

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         echo "✅ Successfully created tag: $TAG_NAME"
 
   build-and-release:
-    name: Build and Release to TestFlight
+    name: Build and Release to TestFlight (Public Beta)
     needs: version-check
     if: needs.version-check.outputs.should_release == 'true'
     runs-on: macos-latest
@@ -290,7 +290,7 @@ jobs:
         export LC_ALL=en_US.UTF-8
         export LANG=en_US.UTF-8
 
-        # Run the beta lane (includes waiting for processing and distribution)
+        # Run the beta lane (includes waiting for processing and public beta distribution)
         fastlane beta
 
     - name: Create GitHub Release
@@ -302,8 +302,9 @@ jobs:
           ## 🚀 Version ${{ needs.version-check.outputs.version }}
           Build: ${{ needs.version-check.outputs.build }}
 
-          ### TestFlight
-          This version has been automatically submitted to TestFlight for beta testing.
+          ### TestFlight Public Beta
+          This version has been automatically submitted to TestFlight for public beta testing.
+          External testers will receive email notifications when the build is available.
 
           ### What's New
           - See [commit history](https://github.com/${{ github.repository }}/commits/${{ needs.version-check.outputs.new_tag }}) for changes
@@ -316,6 +317,7 @@ jobs:
     - name: Post release notification
       if: success()
       run: |
-        echo "✅ Successfully released version ${{ needs.version-check.outputs.version }} to TestFlight!"
+        echo "✅ Successfully released version ${{ needs.version-check.outputs.version }} to TestFlight Public Beta!"
         echo "🏷️ Tag: ${{ needs.version-check.outputs.new_tag }}"
         echo "🔢 Build: ${{ needs.version-check.outputs.build }}"
+        echo "📧 External testers will be notified via email"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,3 +106,4 @@ Currently contains only boilerplate test setup.
 - Orientation: Portrait only on iPhone, all orientations on iPad
 - UI Style: Light mode enforced
 - Website submodule: Located at `website/` (separate repository)
+- create PR should always use english

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -78,20 +78,23 @@ platform :ios do
         api_key: api_key,
         app_identifier: "v2er.app",
         skip_submission: false,
-        distribute_external: true,
-        groups: ["External"],  # Default external tester group
-        notify_external_testers: true,
+        distribute_external: true,  # 发布到外部测试者（公测）
+        groups: ["Public Beta", "External Testers", "Beta Testers"],  # 公测群组
+        notify_external_testers: true,  # 发送邮件通知
         uses_non_exempt_encryption: false,
-        submit_beta_review: true,
+        submit_beta_review: true,  # 自动提交Beta审核
         wait_for_uploaded_build: true,
+        beta_app_description: "V2er 是一个优雅的 V2EX 第三方客户端",
+        beta_app_feedback_email: "support@v2er.app",
+        demo_account_required: false,
         beta_app_review_info: {
           contact_email: "support@v2er.app",
           contact_first_name: "V2er",
           contact_last_name: "Support",
-          contact_phone: "+1234567890",
+          contact_phone: "+86 1234567890",
           demo_account_name: "",
           demo_account_password: "",
-          notes: "This is a V2EX forum client app. No special account needed for testing."
+          notes: "这是一个 V2EX 论坛的第三方客户端应用，测试不需要特殊账号。"
         }
       )
 
@@ -160,13 +163,25 @@ platform :ios do
       skip_waiting_for_build_processing: false,  # Wait for processing before distribution
       wait_processing_interval: 30,  # Check every 30 seconds
       wait_processing_timeout_duration: 900,  # Wait up to 15 minutes for processing
-      distribute_external: true,  # Distribute to external testers
+      distribute_external: true,  # 发布到外部测试者（公测）
       distribute_only: false,  # Upload and distribute in one action
-      groups: ["External Testers", "Beta Testers"],  # Try common group names
+      groups: ["Public Beta", "External Testers", "Beta Testers"],  # 公测群组
       changelog: "Bug fixes and improvements",
-      notify_external_testers: true,  # Send email notifications
+      notify_external_testers: true,  # 发送邮件通知给外部测试者
       uses_non_exempt_encryption: false,  # Required for automatic distribution
-      submit_beta_review: true  # Automatically submit for beta review if needed
+      submit_beta_review: true,  # 自动提交Beta审核
+      beta_app_description: "V2er 是一个优雅的 V2EX 第三方客户端",
+      beta_app_feedback_email: "support@v2er.app",
+      demo_account_required: false,  # 不需要演示账号
+      beta_app_review_info: {
+        contact_email: "support@v2er.app",
+        contact_first_name: "V2er",
+        contact_last_name: "Support",
+        contact_phone: "+86 1234567890",
+        demo_account_name: "",
+        demo_account_password: "",
+        notes: "这是一个 V2EX 论坛的第三方客户端应用，测试不需要特殊账号。"
+      }
     )
 
     # Notify success

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -78,13 +78,13 @@ platform :ios do
         api_key: api_key,
         app_identifier: "v2er.app",
         skip_submission: false,
-        distribute_external: true,  # 发布到外部测试者（公测）
-        groups: ["Public Beta", "External Testers", "Beta Testers"],  # 公测群组
-        notify_external_testers: true,  # 发送邮件通知
+        distribute_external: true,  # Distribute to external testers (public beta)
+        groups: ["Public Beta", "External Testers", "Beta Testers"],  # Public beta groups
+        notify_external_testers: true,  # Send email notifications
         uses_non_exempt_encryption: false,
-        submit_beta_review: true,  # 自动提交Beta审核
+        submit_beta_review: true,  # Automatically submit for Beta review
         wait_for_uploaded_build: true,
-        beta_app_description: "V2er 是一个优雅的 V2EX 第三方客户端",
+        beta_app_description: "V2er is an elegant third-party client for V2EX forum",
         beta_app_feedback_email: "support@v2er.app",
         demo_account_required: false,
         beta_app_review_info: {
@@ -94,7 +94,7 @@ platform :ios do
           contact_phone: "+86 1234567890",
           demo_account_name: "",
           demo_account_password: "",
-          notes: "这是一个 V2EX 论坛的第三方客户端应用，测试不需要特殊账号。"
+          notes: "This is a third-party client app for V2EX forum. No special account needed for testing."
         }
       )
 
@@ -163,16 +163,16 @@ platform :ios do
       skip_waiting_for_build_processing: false,  # Wait for processing before distribution
       wait_processing_interval: 30,  # Check every 30 seconds
       wait_processing_timeout_duration: 900,  # Wait up to 15 minutes for processing
-      distribute_external: true,  # 发布到外部测试者（公测）
+      distribute_external: true,  # Distribute to external testers (public beta)
       distribute_only: false,  # Upload and distribute in one action
-      groups: ["Public Beta", "External Testers", "Beta Testers"],  # 公测群组
+      groups: ["Public Beta", "External Testers", "Beta Testers"],  # Public beta groups
       changelog: "Bug fixes and improvements",
-      notify_external_testers: true,  # 发送邮件通知给外部测试者
+      notify_external_testers: true,  # Send email notifications to external testers
       uses_non_exempt_encryption: false,  # Required for automatic distribution
-      submit_beta_review: true,  # 自动提交Beta审核
-      beta_app_description: "V2er 是一个优雅的 V2EX 第三方客户端",
+      submit_beta_review: true,  # Automatically submit for Beta review
+      beta_app_description: "V2er is an elegant third-party client for V2EX forum",
       beta_app_feedback_email: "support@v2er.app",
-      demo_account_required: false,  # 不需要演示账号
+      demo_account_required: false,  # No demo account required
       beta_app_review_info: {
         contact_email: "support@v2er.app",
         contact_first_name: "V2er",
@@ -180,7 +180,7 @@ platform :ios do
         contact_phone: "+86 1234567890",
         demo_account_name: "",
         demo_account_password: "",
-        notes: "这是一个 V2EX 论坛的第三方客户端应用，测试不需要特殊账号。"
+        notes: "This is a third-party client app for V2EX forum. No special account needed for testing."
       }
     )
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -91,9 +91,7 @@ platform :ios do
           contact_email: "support@v2er.app",
           contact_first_name: "V2er",
           contact_last_name: "Support",
-          contact_phone: "+86 1234567890",
-          demo_account_name: "",
-          demo_account_password: "",
+          contact_phone: "+86 13800138000",
           notes: "This is a third-party client app for V2EX forum. No special account needed for testing."
         }
       )
@@ -177,9 +175,7 @@ platform :ios do
         contact_email: "support@v2er.app",
         contact_first_name: "V2er",
         contact_last_name: "Support",
-        contact_phone: "+86 1234567890",
-        demo_account_name: "",
-        demo_account_password: "",
+        contact_phone: "+86 13800138000",
         notes: "This is a third-party client app for V2EX forum. No special account needed for testing."
       }
     )


### PR DESCRIPTION
## Overview
Update Release Pipeline configuration to change TestFlight distribution from internal testing to public beta testing, allowing more users to participate in testing.

## Changes

### Fastfile Configuration Updates
- ✅ Confirmed `distribute_external: true` is enabled (distribute to external testers)
- ✅ Added "Public Beta" test group name
- ✅ Enhanced beta review info configuration with detailed information
- ✅ Added app description and contact information
- ✅ Set `demo_account_required: false` (no demo account needed)
- ✅ Enabled email notifications with `notify_external_testers: true`

### GitHub Actions Workflow Updates
- ✅ Updated job name to "Build and Release to TestFlight (Public Beta)"
- ✅ Clarified public beta status in GitHub Release notes
- ✅ Added note about external tester email notifications

## Impact
- New releases will automatically be submitted to TestFlight public beta
- External testers will receive email notifications for new builds
- Builds must pass Apple's Beta Review before distribution
- Public beta users can join testing directly via TestFlight link

## Test Plan
- [ ] Verify CI/CD pipeline runs successfully
- [ ] Confirm releases are correctly submitted to public beta
- [ ] Verify external testers receive email notifications
- [ ] Check Beta review information displays correctly

🤖 Generated with [Claude Code](https://claude.ai/code)